### PR TITLE
Adding the common directory and api TLS tests to neutron-lbaas repo

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py
@@ -1,0 +1,317 @@
+# Copyright 2016 Rackspace US Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from barbicanclient import client as barbican_client
+from keystoneauth1 import session
+from keystoneauth1 import identity
+from keystoneclient.v2_0 import client as v2_client
+from keystoneclient.v3 import client as v3_client
+from tempest import config
+from tempest.lib.common.utils import data_utils
+from tempest.lib import decorators
+from tempest.lib import exceptions as ex
+from tempest import test
+
+from neutron_lbaas.tests.tempest.v2.api import base
+from neutron_lbaas.tests.tempest.v2.common import barbican_helper
+
+config = config.CONF
+
+
+class TLSListenersTestJSON(base.BaseTestCase):
+
+    """
+    Tests the following operations in the Neutron-LBaaS API using the
+    REST client for Listeners with TLS:
+
+        list listeners
+        create listener
+        get listener
+        update listener
+        delete listener
+    """
+
+    @classmethod
+    def resource_setup(cls):
+        super(TLSListenersTestJSON, cls).resource_setup()
+        if not test.is_extension_enabled('lbaas', 'network'):
+            msg = "lbaas extension not enabled."
+            raise cls.skipException(msg)
+        network_name = data_utils.rand_name('network-')
+        cls.network = cls.create_network(network_name)
+        cls.subnet = cls.create_subnet(cls.network)
+        cls.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
+                                'vip_subnet_id': cls.subnet['id']}
+        cls.load_balancer = cls._create_active_load_balancer(
+            **cls.create_lb_kwargs)
+        cls.protocol = 'TERMINATED_HTTPS'
+        cls.port = 443
+        cls.load_balancer_id = cls.load_balancer['id']
+
+        # Barbican setup
+        client_kwargs = {
+            'username': config.auth.admin_username,
+            'password': config.auth.admin_password,
+            'tenant_name': config.auth.admin_project_name,
+            'auth_url': config.identity.uri
+        }
+        if config.identity.auth_version.lower() == 'v2':
+            cls.keystone_client = v2_client.Client(**client_kwargs)
+        elif config.identity.auth_version.lower() == 'v3':
+            client_kwargs['auth_url'] = config.identity.uri_v3
+            cls.keystone_client = v3_client.Client(**client_kwargs)
+        else:
+            raise Exception('Unknown authentication version')
+
+        # TODO(): Keystone should load service endpoint...
+        cls.auth = identity.v2.Password(**client_kwargs)
+
+        # create a Keystone session using the auth plugin we just created
+        keystone_session = session.Session(auth=cls.auth)
+
+        cls.barbican_client = barbican_client.Client(session=keystone_session)
+
+        cls.barbican_helper = barbican_helper.BarbicanTestHelper(
+            cls.barbican_client)
+        tls_container_ref = cls.barbican_helper.create_barbican_resources()
+        cls.default_tls_container_ref = tls_container_ref
+        cls.non_existent_tls_container_ref = (
+            "http://127.0.0.1:9311/v1/containers/"
+            "c2266944-c837-46e9-80f5-455abcc8c73c")
+        cls.empty_uuid_tls_container_ref = (
+            "http://127.0.0.1:9311/v1/containers/")
+        cls.create_listener_kwargs = {
+            'loadbalancer_id': cls.load_balancer_id,
+            'protocol': cls.protocol,
+            'protocol_port': cls.port,
+            'default_tls_container_ref': cls.default_tls_container_ref}
+        cls.listener = cls._create_listener(**cls.create_listener_kwargs)
+        cls.listener_id = cls.listener['id']
+
+    @test.attr(type='smoke')
+    def test_get_tls_listener(self):
+        """Test get tls listener"""
+        listener = self.listeners_client.get_listener(
+            self.listener_id)
+        self.assertEqual(self.listener, listener)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='smoke')
+    def test_list_tls_listeners(self):
+        """Test get tls listeners with one listener"""
+        listeners = self.listeners_client.list_listeners()
+        self.assertEqual(len(listeners), 1)
+        self.assertIn(self.listener, listeners)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='smoke')
+    def test_list_tls_listeners_two(self):
+        """Test get listeners with two tls listeners"""
+        create_new_listener_kwargs = self.create_listener_kwargs
+        create_new_listener_kwargs['protocol_port'] = 8080
+        new_listener = self._create_listener(
+            **create_new_listener_kwargs)
+        new_listener_id = new_listener['id']
+        self.addCleanup(self._delete_listener, new_listener_id)
+        self._check_status_tree(
+            load_balancer_id=self.load_balancer_id,
+            listener_ids=[self.listener_id, new_listener_id])
+        listeners = self.listeners_client.list_listeners()
+        self.assertEqual(len(listeners), 2)
+        self.assertIn(self.listener, listeners)
+        self.assertIn(new_listener, listeners)
+        self.assertNotEqual(self.listener, new_listener)
+
+    @test.attr(type='smoke')
+    def test_create_tls_listener(self):
+        """Test create tls listener"""
+        create_new_listener_kwargs = self.create_listener_kwargs
+        create_new_listener_kwargs['protocol_port'] = 8081
+        new_listener = self._create_listener(
+            **create_new_listener_kwargs)
+        new_listener_id = new_listener['id']
+        self.addCleanup(self._delete_listener, new_listener_id)
+        self._check_status_tree(
+            load_balancer_id=self.load_balancer_id,
+            listener_ids=[self.listener_id, new_listener_id])
+        listener = self.listeners_client.get_listener(
+            new_listener_id)
+        self.assertEqual(new_listener, listener)
+        self.assertNotEqual(self.listener, new_listener)
+
+    @test.attr(type='negative')
+    def test_create_listener_invalid_tls_container(self):
+        """Test create a listener with an invalid tls container"""
+        self.assertRaises(ex.BadRequest,
+                          self._create_listener,
+                          loadbalancer_id=self.load_balancer_id,
+                          protocol_port=self.port,
+                          protocol=self.protocol,
+                          default_tls_container_ref='a' * 256)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='negative')
+    def test_create_listener_empty_tls_container(self):
+        """Test create a listener with an empty tls container"""
+        self.assertRaises(ex.BadRequest,
+                          self._create_listener,
+                          loadbalancer_id=self.load_balancer_id,
+                          protocol_port=self.port,
+                          protocol=self.protocol,
+                          default_tls_container_ref='')
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='negative')
+    def test_create_listener_nonexistent_tls_container(self):
+        """Test create a listener with a nonexistent tls container"""
+        self.assertRaises(ex.NotFound,
+                          self._create_listener,
+                          loadbalancer_id=self.load_balancer_id,
+                          protocol_port=self.port,
+                          protocol=self.protocol,
+                          default_tls_container_ref=(
+                              self.non_existent_tls_container_ref))
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='negative')
+    def test_create_listener_empty_uuid_tls_container(self):
+        """Test create a listener with an empty uuid tls container"""
+        self.assertRaises(ex.NotFound,
+                          self._create_listener,
+                          loadbalancer_id=self.load_balancer_id,
+                          protocol_port=self.port,
+                          protocol=self.protocol,
+                          default_tls_container_ref=(
+                              self.empty_uuid_tls_container_ref))
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='smoke')
+    def test_update_tls_listener(self):
+        """Test update tls listener"""
+        new_tls_container_ref = (
+            self.barbican_helper.create_barbican_resources())
+        self._update_listener(self.listener_id,
+                              default_tls_container_ref=new_tls_container_ref)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+        listener = self.listeners_client.get_listener(
+            self.listener_id)
+        self.assertEqual(listener.get('default_tls_container_ref'),
+                         new_tls_container_ref)
+
+    @test.attr(type='negative')
+    def test_update_listener_invalid_tls_container(self):
+        """Test update a listener with an invalid tls container"""
+        self.assertRaises(ex.BadRequest,
+                          self._update_listener,
+                          listener_id=self.listener_id,
+                          default_tls_container_ref='a' * 256)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='negative')
+    def test_update_listener_tls_protocol(self):
+        """Test update a tls listener with immutable attribute: protocol"""
+        self.assertRaises(ex.BadRequest,
+                          self._update_listener,
+                          listener_id=self.listener_id,
+                          protocol="HTTP")
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='smoke')
+    def test_update_listener_tls_port(self):
+        """Test update a tls listener with immutable attribute: port"""
+        self.assertRaises(ex.BadRequest,
+                          self._update_listener,
+                          listener_id=self.listener_id,
+                          port=80)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @decorators.skip_because(bug="1569536")
+    @test.attr(type='smoke')
+    def test_update_listener_empty_tls_container(self):
+        """Test remove TLS from listener with an empty tls container"""
+        # Remove TLS from listener
+        self._update_listener(self.listener_id,
+                              default_tls_container_ref='')
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+        listener = self.listeners_client.get_listener(
+            self.listener_id)
+        self.assertEqual('', listener.get('default_tls_container_ref'))
+
+    @decorators.skip_because(bug="1569536")
+    @test.attr(type='smoke')
+    def test_update_listener_none_tls_container(self):
+        """Test remove TLS from listener with a null tls container"""
+        self._update_listener(self.listener_id,
+                              default_tls_container_ref=None)
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+        listener = self.listeners_client.get_listener(
+            self.listener_id)
+        self.assertEqual(None, listener.get('default_tls_container_ref'))
+
+    @test.attr(type='negative')
+    def test_update_listener_nonexistent_tls_container(self):
+        """Test update a listener with a nonexistent tls container"""
+        self.assertRaises(ex.NotFound,
+                          self._update_listener,
+                          listener_id=self.listener_id,
+                          default_tls_container_ref=(
+                              self.non_existent_tls_container_ref))
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='negative')
+    def test_update_listener_empty_uuid_tls_container(self):
+        """Test update a listener with a empty uuid tls container"""
+        self.assertRaises(ex.NotFound,
+                          self._update_listener,
+                          listener_id=self.listener_id,
+                          default_tls_container_ref=(
+                              self.empty_uuid_tls_container_ref))
+        self._check_status_tree(load_balancer_id=self.load_balancer_id,
+                                listener_ids=[self.listener_id])
+
+    @test.attr(type='smoke')
+    def test_delete_tls_listener(self):
+        """Test delete listener"""
+        new_tls_container_ref = (
+            self.barbican_helper.create_barbican_resources())
+        create_new_listener_kwargs = self.create_listener_kwargs
+        create_new_listener_kwargs['default_tls_container_ref'] = (
+            new_tls_container_ref)
+        new_listener = self._create_listener(**create_new_listener_kwargs)
+        new_listener_id = new_listener['id']
+        self._check_status_tree(
+            load_balancer_id=self.load_balancer_id,
+            listener_ids=[self.listener_id, new_listener_id])
+        listener = self.listeners_client.get_listener(
+            new_listener_id)
+        self.assertEqual(new_listener, listener)
+        self.assertNotEqual(self.listener, new_listener)
+        self._delete_listener(new_listener_id)
+        self.assertRaises(ex.NotFound,
+                          self.listeners_client.get_listener,
+                          new_listener_id)

--- a/neutron_lbaas/tests/tempest/v2/common/barbican_helper.py
+++ b/neutron_lbaas/tests/tempest/v2/common/barbican_helper.py
@@ -1,0 +1,134 @@
+# Copyright 2015-2016 Hewlett-Packard Development Company, L.P.
+# Copyright 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from OpenSSL import crypto
+from oslo_log import log as logging
+import six
+from tempest import config
+
+config = config.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class BarbicanTestHelper(object):
+
+    def __init__(self, barbican_client):
+        self.barbican_client = barbican_client
+
+    def _create_certificate_chain(self):
+        """
+        Construct and return a chain of certificates.
+
+            1. A new self-signed certificate authority certificate (cacert)
+            2. A new intermediate certificate signed by cacert (icert)
+            3. A new server certificate signed by icert (scert)
+            4. Returns server certificate and server key (s_cert, s_key)
+        """
+        caext = crypto.X509Extension('basicConstraints', False, 'CA:true')
+
+        # Step 1
+        cakey = crypto.PKey()
+        cakey.generate_key(crypto.TYPE_RSA, 1024)
+        cacert = crypto.X509()
+        cacert.get_subject().CN = "Authority Certificate"
+        cacert.set_issuer(cacert.get_subject())
+        cacert.set_pubkey(cakey)
+        cacert.gmtime_adj_notBefore(0)
+        cacert.gmtime_adj_notAfter(315360000)
+        cacert.set_serial_number(1)
+        cacert.sign(cakey, "sha1")
+        self.ca_cert = crypto.dump_certificate(crypto.FILETYPE_PEM, cacert)
+        self.ca_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey)
+
+        # Step 2
+        ikey = crypto.PKey()
+        ikey.generate_key(crypto.TYPE_RSA, 1024)
+        icert = crypto.X509()
+        icert.get_subject().CN = "ca-int@acme.com"
+        icert.set_issuer(icert.get_subject())
+        icert.set_pubkey(ikey)
+        icert.gmtime_adj_notBefore(0)
+        # 315360000 can be substituted with 10*365*24*60*60
+        icert.gmtime_adj_notAfter(315360000)
+        icert.add_extensions([caext])
+        icert.set_serial_number(1)
+        icert.sign(cakey, "sha1")
+        self.i_cert = crypto.dump_certificate(crypto.FILETYPE_PEM, cacert)
+        self.i_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey)
+
+        # Step 3
+        skey = crypto.PKey()
+        skey.generate_key(crypto.TYPE_RSA, 1024)
+        scert = crypto.X509()
+        scert.get_subject().CN = "server@acme.com"
+        scert.set_issuer(scert.get_subject())
+        scert.set_pubkey(skey)
+        scert.gmtime_adj_notBefore(0)
+        scert.gmtime_adj_notAfter(315360000)
+        scert.add_extensions([
+            crypto.X509Extension('basicConstraints', True, 'CA:false')])
+        scert.set_serial_number(1)
+        scert.sign(ikey, "sha1")
+        self.s_cert = crypto.dump_certificate(crypto.FILETYPE_PEM, icert)
+        self.s_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, ikey)
+
+        return [(self.s_key, self.s_cert)]
+
+    def _create_container_and_secrets(self):
+        cert = self.barbican_client.secrets.create(
+            name='server_cert',
+            algorithm='aes',
+            bit_length=256,
+            mode='cbc',
+            payload=self.s_cert,
+            payload_content_type='text/plain'
+        )
+        cert_store = cert.store()
+        cert_secret = self.barbican_client.secrets.get(cert_store)
+
+        pk = self.barbican_client.secrets.create(
+            name='server_key',
+            algorithm='aes',
+            bit_length=256,
+            mode='cbc',
+            payload=self.s_key,
+            payload_content_type='text/plain'
+        )
+        pk_store = pk.store()
+        pk_secret = self.barbican_client.secrets.get(pk_store)
+
+        container = (
+            self.barbican_client.containers.create_certificate(
+                name='tls-lb-container',
+                certificate=cert_secret,
+                private_key=pk_secret
+            )
+        )
+        tls_container_ref = container.store()
+        return tls_container_ref
+
+    def create_barbican_resources(self):
+        self._create_certificate_chain()
+        return self._create_container_and_secrets()
+
+    def cleanup_barbican(self, tls_container_id):
+        certificate_container = self.barbican_client.containers.get(
+            tls_container_id)
+        for type, ref in six.iteritems(certificate_container.secret_refs):
+            self.barbican_client.secrets.delete(secret_ref=ref)
+        certificate_container.delete()
+

--- a/neutron_lbaas/tests/tempest/v2/scenario/base.py
+++ b/neutron_lbaas/tests/tempest/v2/scenario/base.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Hewlett-Packard Development Company, L.P.
+# Copyright 2015-2016 Hewlett-Packard Development Company, L.P.
 # Copyright 2016 Rackspace Inc.
 # All Rights Reserved.
 #
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import cookielib
+import select
 import shlex
 import socket
 import subprocess
@@ -23,14 +23,16 @@ import time
 
 from oslo_log import log as logging
 import six
+from six.moves import http_cookiejar
 from six.moves.urllib import error
 from six.moves.urllib import request as urllib2
 from tempest.common import waiters
 from tempest import config
 from tempest import exceptions
+from tempest.lib.common import ssh
 from tempest.lib import exceptions as lib_exc
 from tempest.scenario import manager
-from tempest.scenario import network_resources as net_resources
+
 from tempest import test
 
 from neutron_lbaas._i18n import _
@@ -70,6 +72,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
 
     def setUp(self):
         super(BaseTestCase, self).setUp()
+
         self.servers_keypairs = {}
         self.servers = {}
         self.members = []
@@ -107,7 +110,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
             msg = 'LBaaS Extension is not enabled'
             raise cls.skipException(msg)
         if not (cfg.project_networks_reachable or cfg.public_network_id):
-            msg = ('Either tenant_networks_reachable must be "true", or '
+            msg = ('Either project_networks_reachable must be "true", or '
                    'public_network_id must be defined.')
             raise cls.skipException(msg)
 
@@ -125,10 +128,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
 
         if tenant_net:
             tenant_subnet = self._list_subnets(tenant_id=self.tenant_id)[0]
-            self.subnet = net_resources.DeletableSubnet(
-                subnets_client=self.subnets_client,
-                routers_client=self.routers_client,
-                **tenant_subnet)
+            self.subnet = tenant_subnet['subnet']
             self.network = tenant_net
         else:
             self.network = self._get_network_by_name(
@@ -137,8 +137,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
             # with the fixed network is the one we want.  In the future, we
             # should instead pull a subnet id from config, which is set by
             # devstack/admin/etc.
-            subnet = self._list_subnets(network_id=self.network['id'])[0]
-            self.subnet = net_resources.AttributeDict(subnet)
+            self.subnet = self._list_subnets(network_id=self.network['id'])[0]
 
     def _create_security_group_for_test(self):
         self.security_group = self._create_security_group(
@@ -192,6 +191,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
             public_network_id = config.network.public_network_id
             floating_ip = self.create_floating_ip(
                 server, public_network_id)
+            self.check_floating_ip_status(floating_ip, "ACTIVE")
             self.floating_ips[floating_ip] = server
             self.server_ips[server['id']] = floating_ip.floating_ip_address
         else:
@@ -231,14 +231,22 @@ class BaseTestCase(manager.NetworkScenarioTest):
         1. SSH to the instance
         2. Start two http backends listening on ports 80 and 88 respectively
         """
+        LOG.info(('self.server_ips looks like this: {0}'.format(
+            self.server_ips)))
+
         for server_id, ip in six.iteritems(self.server_ips):
+
+            LOG.info(('processing server_id {0}  ip: {1}'.format(
+                server_id, ip)))
+
             private_key = self.servers_keypairs[server_id]['private_key']
             server = self.servers_client.show_server(server_id)['server']
             server_name = server['name']
             username = config.validation.image_ssh_user
-            ssh_client = self.get_remote_client(
-                ip_address=ip,
-                private_key=private_key)
+
+            self.ssh_client = ssh.Client(host=ip, username=username,
+                                         pkey=private_key)
+            self.ssh_client.test_connection_auth()
 
             # Write a backend's response into a file
             resp = ('echo -ne "HTTP/1.1 200 OK\r\nContent-Length: 7\r\n'
@@ -257,14 +265,15 @@ class BaseTestCase(manager.NetworkScenarioTest):
                                            "/tmp/script1",
                                            ip,
                                            username, key.name)
-
             # Start netcat
             start_server = ('while true; do '
                             'sudo nc -ll -p %(port)s -e sh /tmp/%(script)s; '
                             'done > /dev/null &')
             cmd = start_server % {'port': self.port1,
                                   'script': 'script1'}
-            ssh_client.exec_command(cmd)
+            self.exec_command(cmd)
+            LOG.info(('Executing cmd on server {0} ip {1}: {2}'.format(
+                server_id, ip, cmd)))
 
             if len(self.server_ips) == 1:
                 with tempfile.NamedTemporaryFile() as script:
@@ -279,20 +288,22 @@ class BaseTestCase(manager.NetworkScenarioTest):
                                                username, key.name)
                 cmd = start_server % {'port': self.port2,
                                       'script': 'script2'}
-                ssh_client.exec_command(cmd)
+                self.exec_command(cmd)
 
-    def _create_listener(self, load_balancer_id):
-        """Create a listener with HTTP protocol listening on port 80."""
+    def _create_listener(self, load_balancer_id, default_tls_container=None,
+                         protocol='HTTP', port=80):
+        """Create a listener."""
         self.listener = self.listeners_client.create_listener(
             loadbalancer_id=load_balancer_id,
-            protocol='HTTP', protocol_port=80)
+            protocol=protocol, protocol_port=port,
+            default_tls_container_ref=default_tls_container)
         self.assertTrue(self.listener)
         self.addCleanup(self._cleanup_listener, self.listener.get('id'),
                         load_balancer_id=load_balancer_id)
         return self.listener
 
     def _create_health_monitor(self):
-        """Create a pool with ROUND_ROBIN algorithm."""
+        """Create a health monitor."""
         self.hm = self.health_monitors_client.create_health_monitor(
             type='HTTP', max_retries=5, delay=3, timeout=5,
             pool_id=self.pool['id'])
@@ -301,13 +312,14 @@ class BaseTestCase(manager.NetworkScenarioTest):
                         self.hm.get('id'),
                         load_balancer_id=self.load_balancer['id'])
 
-    def _create_pool(self, listener_id, persistence_type=None,
+    def _create_pool(self, listener_id, protocol='HTTP',
+                     lb_algorithm='ROUND_ROBIN', persistence_type=None,
                      cookie_name=None):
-        """Create a pool with ROUND_ROBIN algorithm."""
+        """Create a pool."""
         pool = {
             "listener_id": listener_id,
-            "lb_algorithm": "ROUND_ROBIN",
-            "protocol": "HTTP"
+            "lb_algorithm": lb_algorithm,
+            "protocol": protocol
         }
         if persistence_type:
             pool.update({'session_persistence': {'type': persistence_type}})
@@ -342,8 +354,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
 
     def _create_members(self, load_balancer_id=None, pool_id=None,
                         subnet_id=None):
-        """
-        Create two members.
+        """Create two members.
 
         In case there is only one server, create both members with the same ip
         but with different ports to listen on.
@@ -383,7 +394,11 @@ class BaseTestCase(manager.NetworkScenarioTest):
         # Check for floating ip status before you check load-balancer
         self.check_floating_ip_status(floating_ip, "ACTIVE")
 
-    def _create_load_balancer(self, ip_version=4, persistence_type=None):
+    def _create_load_balancer(self, ip_version=4, persistence_type=None,
+                              default_tls_container_ref=None,
+                              listener_protocol='HTTP',
+                              port=80,
+                              pool_protocol='HTTP'):
         self.create_lb_kwargs = {'tenant_id': self.tenant_id,
                                  'vip_subnet_id': self.subnet['id']}
         self.load_balancer = self.load_balancers_client.create_load_balancer(
@@ -392,10 +407,15 @@ class BaseTestCase(manager.NetworkScenarioTest):
         self.addCleanup(self._cleanup_load_balancer, load_balancer_id)
         self._wait_for_load_balancer_status(load_balancer_id)
 
-        listener = self._create_listener(load_balancer_id=load_balancer_id)
+        listener = self._create_listener(
+            load_balancer_id=load_balancer_id,
+            default_tls_container=default_tls_container_ref,
+            protocol=listener_protocol,
+            port=port)
         self._wait_for_load_balancer_status(load_balancer_id)
 
         self.pool = self._create_pool(listener_id=listener.get('id'),
+                                      protocol=pool_protocol,
                                       persistence_type=persistence_type)
         self._wait_for_load_balancer_status(load_balancer_id)
 
@@ -410,10 +430,9 @@ class BaseTestCase(manager.NetworkScenarioTest):
         if ip_version == 4:
             if (config.network.public_network_id and not
                     config.network.project_networks_reachable):
-                load_balancer = net_resources.AttributeDict(self.load_balancer)
-                self._assign_floating_ip_to_lb_vip(load_balancer)
+                self._assign_floating_ip_to_lb_vip(self.load_balancer)
                 self.vip_ip = self.floating_ips[
-                    load_balancer.id][0]['floating_ip_address']
+                    self.load_balancer.id][0]['floating_ip_address']
 
         # Currently the ovs-agent is not enforcing security groups on the
         # vip port - see https://bugs.launchpad.net/neutron/+bug/1163569
@@ -485,22 +504,28 @@ class BaseTestCase(manager.NetworkScenarioTest):
                   pool_id=pool_id,
                   type=sp_type))
 
-    def _check_load_balancing(self):
-        """
+    def _check_load_balancing(self, protocol='http', port=80):
+        """Check Load Balancing between 2 servers
+
         1. Send NUM requests on the floating ip associated with the VIP
         2. Check that the requests are shared between the two servers
         """
-
-        self._check_connection(self.vip_ip)
-        counters = self._send_requests(self.vip_ip, ["server1", "server2"])
+        self._check_connection(check_ip=self.vip_ip,
+                               protocol=protocol,
+                               port=port)
+        counters = self._send_requests(vip_ip=self.vip_ip,
+                                       servers=["server1", "server2"],
+                                       protocol=protocol)
         for member, counter in six.iteritems(counters):
             self.assertGreater(counter, 0, 'Member %s never balanced' % member)
 
-    def _check_connection(self, check_ip, port=80):
-        def try_connect(check_ip, port):
+    def _check_connection(self, check_ip, protocol='http', port=80):
+        """Checks connection of the back end servers"""
+        def try_connect(check_ip, protocol, port):
             try:
-                resp = urllib2.urlopen("http://{0}:{1}/".format(check_ip,
-                                                                port))
+                resp = urllib2.urlopen("{0}://{1}:{2}/".format(protocol,
+                                                               check_ip,
+                                                               port))
                 if resp.getcode() == 200:
                     return True
                 return False
@@ -508,19 +533,19 @@ class BaseTestCase(manager.NetworkScenarioTest):
                 return False
             except error.HTTPError:
                 return False
-        timeout = config.validation .ping_timeout
+        timeout = config.validation.ping_timeout
         start = time.time()
-        while not try_connect(check_ip, port):
+        while not try_connect(check_ip, protocol, port):
             if (time.time() - start) > timeout:
                 message = "Timed out trying to connect to %s" % check_ip
                 raise exceptions.TimeoutException(message)
 
-    def _send_requests(self, vip_ip, servers):
+    def _send_requests(self, vip_ip, servers, protocol='http'):
         counters = dict.fromkeys(servers, 0)
         for i in range(self.num):
             try:
-                server = urllib2.urlopen("http://{0}/".format(vip_ip),
-                                         None, 2).read()
+                server = urllib2.urlopen("{0}://{1}/".format(
+                    protocol, vip_ip), None, 2).read()
                 counters[server] += 1
             # HTTP exception means fail of server, so don't increase counter
             # of success and continue connection tries
@@ -539,8 +564,8 @@ class BaseTestCase(manager.NetworkScenarioTest):
                                  'Member %s is not balanced' % member)
 
     def _check_load_balancing_after_deleting_resources(self):
-        """
-        Check that the requests are not sent to any servers
+        """Check that the requests are not sent to any servers
+
         Assert that no traffic is sent to any servers
         """
         counters = self._send_requests(self.vip_ip, ["server1", "server2"])
@@ -588,7 +613,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
         """Check cookie persistence types by injecting cookies in requests."""
 
         # Send first request and get cookie from the server's response
-        cj = cookielib.CookieJar()
+        cj = http_cookiejar.CookieJar()
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
         opener.open("http://{0}/".format(self.vip_ip))
         resp = []
@@ -617,3 +642,78 @@ class BaseTestCase(manager.NetworkScenarioTest):
                       "output {2}, error {3}").format(cmd, proc.returncode,
                                                       stdout, stderr))
         return stdout
+
+    def _is_timed_out(self, start_time, timeout=100):
+        return (time.time() - timeout) > start_time
+
+    @staticmethod
+    def _can_system_poll():
+        return hasattr(select, 'poll')
+
+    def exec_command(self, cmd, encoding="utf-8",
+                     channel_timeout=10, buf_size=1024):
+        """Execute the specified command on the server
+        Note that this method is reading whole command outputs to memory, thus
+        shouldn't be used for large outputs.
+        :param str cmd: Command to run at remote server.
+        :param str encoding: Encoding for result from paramiko.
+                             Result will not be decoded if None.
+        :returns: data read from standard output of the command.
+        :raises: SSHExecCommandFailed if command returns nonzero
+                 status. The exception contains command status stderr content.
+        :raises: TimeoutException if cmd doesn't end when timeout expires.
+        """
+
+        ssh = self.ssh_client._get_ssh_connection()
+        transport = ssh.get_transport()
+        with transport.open_session() as channel:
+            channel.fileno()  # Register event pipe
+            channel.exec_command(cmd)
+            channel.shutdown_write()
+            exit_status = channel.recv_exit_status()
+
+            # If the executing host is linux-based, poll the channel
+            if self._can_system_poll():
+                out_data_chunks = []
+                err_data_chunks = []
+                poll = select.poll()
+                poll.register(channel, select.POLLIN)
+                start_time = time.time()
+
+                while True:
+                    ready = poll.poll(channel_timeout)
+                    if not any(ready):
+                        if not self._is_timed_out(start_time):
+                            continue
+                        raise exceptions.TimeoutException(
+                            "Command: '{0}' executed on host '{1}'.".format(
+                                cmd, self.host))
+                    if not ready[0]:  # If there is nothing to read.
+                        continue
+                    out_chunk = err_chunk = None
+                    if channel.recv_ready():
+                        out_chunk = channel.recv(buf_size)
+                        out_data_chunks += out_chunk,
+                    if channel.recv_stderr_ready():
+                        err_chunk = channel.recv_stderr(buf_size)
+                        err_data_chunks += err_chunk,
+                    if not err_chunk and not out_chunk:
+                        break
+                out_data = b''.join(out_data_chunks)
+                err_data = b''.join(err_data_chunks)
+            # Just read from the channels
+            else:
+                out_file = channel.makefile('rb', buf_size)
+                err_file = channel.makefile_stderr('rb', buf_size)
+                out_data = out_file.read()
+                err_data = err_file.read()
+            if encoding:
+                out_data = out_data.decode(encoding)
+                err_data = err_data.decode(encoding)
+
+            if 0 != exit_status:
+                raise exceptions.SSHExecCommandFailed(
+                    command=cmd, exit_status=exit_status,
+                    stderr=err_data, stdout=out_data)
+            return out_data
+

--- a/neutron_lbaas/tests/tempest/v2/scenario/base_tls.py
+++ b/neutron_lbaas/tests/tempest/v2/scenario/base_tls.py
@@ -1,0 +1,84 @@
+# Copyright 2015-2016 Hewlett-Packard Development Company, L.P.
+# Copyright 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from barbicanclient import client as barbican_client
+from keystoneauth1 import session
+from keystoneclient.v2_0 import client as v2_client
+from keystoneclient.v3 import client as v3_client
+from oslo_log import log as logging
+from tempest import config
+
+from neutron_lbaas.tests.tempest.v2.common import barbican_helper
+from neutron_lbaas.tests.tempest.v2.scenario import base
+
+config = config.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class BaseTestCaseTLS(base.BaseTestCase):
+
+    def setUp(self):
+        super(BaseTestCaseTLS, self).setUp()
+        client_kwargs = {
+            'username': config.auth.admin_username,
+            'password': config.auth.admin_password,
+            'tenant_name': config.auth.admin_tenant_name,
+            'auth_url': config.identity.uri
+        }
+        if config.identity.auth_version.lower() == 'v2':
+            self.keystone_client = v2_client.Client(**client_kwargs)
+        elif config.identity.auth_version.lower() == 'v3':
+            client_kwargs['auth_url'] = config.identity.uri_v3
+            self.keystone_client = v3_client.Client(**client_kwargs)
+        else:
+            raise Exception('Unknown authentication version')
+        keystone_session = session.Session(auth=self.keystone_client)
+
+        # TODO(): Keystone should load service endpoint...
+        self.temp_barbican_endpoint = 'http://localhost:9311'
+        self.barbican_client = barbican_client.Client(
+            session=keystone_session, endpoint=self.temp_barbican_endpoint)
+
+        self.barbican_helper = barbican_helper.BarbicanTestHelper(
+            self.barbican_client)
+
+    def _cleanup_loadbalancers(self, tls_container_ref=None):
+        lbs = self.load_balancers_client.list_load_balancers()
+        for lb_entity in lbs:
+            lb_id = lb_entity['id']
+            lb = self.load_balancers_client.get_load_balancer_status_tree(
+                lb_id).get('loadbalancer')
+            for listener in lb.get('listeners'):
+                for pool in listener.get('pools'):
+                    self.delete_wrapper(self.pools_client.delete_pool,
+                                        pool.get('id'))
+                    self._wait_for_load_balancer_status(lb_id)
+                self.delete_wrapper(self.listeners_client.delete_listener,
+                                    listener.get('id'))
+                self._wait_for_load_balancer_status(lb_id)
+                if tls_container_ref:
+                    self.cleanup_barbican(tls_container_ref)
+            self.delete_wrapper(
+                self.load_balancers_client.delete_load_balancer, lb_id)
+
+    def _create_barbican_resources(self):
+        tls_container_ref = self.barbican_helper.create_barbican_resources()
+        self.assertTrue(tls_container_ref)
+        self.addCleanup(self.barbican_helper.cleanup_barbican,
+                        tls_container_ref)
+        return tls_container_ref
+

--- a/neutron_lbaas/tests/tempest/v2/scenario/test_load_balancer_tls.py
+++ b/neutron_lbaas/tests/tempest/v2/scenario/test_load_balancer_tls.py
@@ -1,0 +1,52 @@
+# Copyright 2015, 2016 Rackspace Inc.
+# Copyright 2016 Hewlett Packard Enterprise Development Company
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from tempest import config
+from tempest import test
+
+from neutron_lbaas.tests.tempest.v2.scenario import base_tls
+
+config = config.CONF
+
+
+class TestLoadBalancerTLS(base_tls.BaseTestCaseTLS):
+
+    """This test checks TLS load balancing
+
+    The following is the scenario outline:
+    1. Create an instance
+    2. SSH to the instance and start two servers
+    3. Create a TLS termination load balancer with two members and
+       ROUND_ROBIN algorithm, associate the VIP with a floating ip
+    4. Send NUM requests to the floating ip and check that they are shared
+       between the two servers.
+    5. SNI (Create additional certificate(s), add to listener sni, verify
+       returned certificates)
+    """
+    @test.services('compute', 'network')
+    def test_load_balancer_tls(self):
+        # Test TLS termination
+        # Verify HaProxy terminates TLS traffic and sends it to the backend
+        self._create_server('server1')
+        self._start_servers()
+        default_tls_container_ref = self._create_barbican_resources()
+        self._create_load_balancer(
+            default_tls_container_ref=default_tls_container_ref,
+            listener_protocol='TERMINATED_HTTPS',
+            port=443,
+            pool_protocol='HTTP')
+        self._check_load_balancing(protocol='https', port=443)
+


### PR DESCRIPTION
@jlongstaf 

**What issues does this address?**

Fixes #6  , #8  

**What's this change do?**

add the new api and scenario TLS test and barbican helper to the neutron-lbaas repo.

**Where should the reviewer start?**

test_listeners_tls.py
test_load_balancer_tls.py
I ran the set of tests in the test_listener_tls against F5 agent and all of the tests passed. The scenario test (test_load_balancer_tlc.py) fails as the rest of scenario tests.

**Any background context?**
The common/ directory and api tests comes from the Gerrit code review: https://review.openstack.org/#/c/164828/
the TLS api test comes from the Gerrit code review: https://review.openstack.org/#/c/304866/
