### PR TITLE
Feature.l7switching

### DIFF
--- a/neutron_lbaas/drivers/f5/driver_v2.py
+++ b/neutron_lbaas/drivers/f5/driver_v2.py
@@ -20,7 +20,7 @@ from oslo_log import log as logging
 
 from neutron_lbaas.drivers import driver_base
 
-VERSION = "9.0.1"
+VERSION = "9.1.0"
 LOG = logging.getLogger(__name__)
 
 
@@ -38,6 +38,8 @@ class F5LBaaSV2Driver(driver_base.LoadBalancerBaseDriver):
         self.pool = PoolManager(self)
         self.member = MemberManager(self)
         self.health_monitor = HealthMonitorManager(self)
+        self.l7policy = L7PolicyManager(self)
+        self.l7rule = L7RuleManager(self)
 
         if not env:
             msg = "F5LBaaSV2Driver cannot be intialized because the "\
@@ -138,3 +140,27 @@ class HealthMonitorManager(driver_base.BaseHealthMonitorManager):
 
     def delete(self, context, health_monitor):
         self.driver.f5.healthmonitor.delete(context, health_monitor)
+
+
+class L7PolicyManager(driver_base.BaseL7PolicyManager):
+
+    def create(self, context, l7policy):
+        self.driver.f5.l7policy.create(context, l7policy)
+
+    def update(self, context, old_l7policy, l7policy):
+        self.driver.f5.l7policy.update(context, old_l7policy, l7policy)
+
+    def delete(self, context, l7policy):
+        self.driver.f5.l7policy.delete(context, l7policy)
+
+
+class L7RuleManager(driver_base.BaseL7RuleManager):
+
+    def create(self, context, l7rule):
+        self.driver.f5.l7rule.create(context, l7rule)
+
+    def update(self, context, old_l7rule, l7rule):
+        self.driver.f5.l7rule.update(context, old_l7rule, l7rule)
+
+    def delete(self, context, l7rule):
+        self.driver.f5.l7rule.delete(context, l7rule)


### PR DESCRIPTION
#### What issues does this address?
Provide L7 content switching support.

#### What's this change do?
Adds support for creating, updating, deleting L7 policies and rules to the F5 LBaaSv2 driver shim.

#### Where should the reviewer start?
driver_v2.py

#### Any background context?
This is the driver shim only, and enables full L7 content switching support implemented in the real F5 LBaaSv2 driver.