### PR TITLE
Update tempest test files to fix various test issues

### DIFF
--- a/neutron_lbaas/tests/tempest/requirements.txt
+++ b/neutron_lbaas/tests/tempest/requirements.txt
@@ -4,4 +4,4 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-tempest>=11.0.0,<12.1.0  # Apache-2.0
+tempest==12.1.0  # Apache-2.0

--- a/neutron_lbaas/tests/tempest/v2/api/base.py
+++ b/neutron_lbaas/tests/tempest/v2/api/base.py
@@ -174,7 +174,7 @@ class BaseTestCase(base.BaseNetworkTest):
                                        operating_status='ONLINE',
                                        delete=False):
         interval_time = 1
-        timeout = 600
+        timeout = 60
         end_time = time.time() + timeout
         lb = {}
         while time.time() < end_time:

--- a/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py
@@ -64,7 +64,7 @@ class MemberTestJSON(base.BaseAdminTestCase):
     def test_create_member_invalid_tenant_id(self):
         """Test create member with invalid tenant_id"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['tenant_id'] = "$232!$pw"
@@ -77,7 +77,7 @@ class MemberTestJSON(base.BaseAdminTestCase):
     def test_create_member_empty_tenant_id(self):
         """Test create member with an empty tenant_id should fail"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['tenant_id'] = ""

--- a/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py
@@ -74,7 +74,7 @@ class MemberTestJSON(base.BaseTestCase):
     @test.attr(type='smoke')
     def test_list_3_members(self):
         """Test that we can list members. """
-        member_ips_exp = set([u"127.0.0.0", u"127.0.0.1", u"127.0.0.2"])
+        member_ips_exp = set([u"128.0.0.0", u"128.0.0.1", u"128.0.0.2"])
         for ip in member_ips_exp:
             member_opts = self.build_member_opts()
             member_opts["address"] = ip
@@ -126,7 +126,7 @@ class MemberTestJSON(base.BaseTestCase):
         missing
         """
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member = self._create_member(self.pool_id, **member_opts)
@@ -145,7 +145,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_missing_required_field_protocol_port(self):
         """Test create a member with missing field protocol_port"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['subnet_id'] = self.subnet_id
         self.assertRaises(ex.BadRequest, self._create_member,
                           self.pool_id, **member_opts)
@@ -155,7 +155,7 @@ class MemberTestJSON(base.BaseTestCase):
         """Test create a member with missing field subnet_id """
         member_opts = {}
         member_opts['protocol_port'] = 80
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         self.assertRaises(ex.BadRequest, self._create_member,
                           self.pool_id, **member_opts)
 
@@ -170,7 +170,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_tenant_id(self):
         """Test create member with invalid tenant_id"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['tenant_id'] = "$232!$pw"
@@ -181,7 +181,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_address(self):
         """Test create member with invalid address"""
         member_opts = {}
-        member_opts['address'] = "127$%<ki"
+        member_opts['address'] = "128$%<ki"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         self.assertRaises(ex.BadRequest, self._create_member,
@@ -191,7 +191,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_protocol_port(self):
         """Test create member with invalid protocol_port"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 8090000
         member_opts['subnet_id'] = self.subnet_id
         self.assertRaises(ex.BadRequest, self._create_member,
@@ -201,7 +201,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_subnet_id(self):
         """Test create member with invalid subnet_id"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = "45k%^"
         self.assertRaises(ex.BadRequest, self._create_member,
@@ -211,7 +211,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_admin_state_up(self):
         """Test create member with invalid admin_state_up"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['admin_state_up'] = "$232!$pw"
@@ -222,7 +222,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_invalid_weight(self):
         """Test create member with invalid weight"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['weight'] = "$232!$pw"
@@ -233,7 +233,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_empty_tenant_id(self):
         """Test create member with an empty tenant_id"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['tenant_id'] = ""
@@ -254,7 +254,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_empty_protocol_port(self):
         """Test create member with an empty protocol_port"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = ""
         member_opts['subnet_id'] = self.subnet_id
         self.assertRaises(ex.BadRequest, self._create_member,
@@ -264,7 +264,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_empty_subnet_id(self):
         """Test create member with empty subnet_id"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = ""
         self.assertRaises(ex.BadRequest, self._create_member,
@@ -274,7 +274,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_empty_admin_state_up(self):
         """Test create member with an empty admin_state_up"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['admin_state_up'] = ""
@@ -285,7 +285,7 @@ class MemberTestJSON(base.BaseTestCase):
     def test_create_member_empty_weight(self):
         """Test create member with an empty weight"""
         member_opts = {}
-        member_opts['address'] = "127.0.0.1"
+        member_opts['address'] = "128.0.0.1"
         member_opts['protocol_port'] = 80
         member_opts['subnet_id'] = self.subnet_id
         member_opts['weight'] = ""
@@ -418,7 +418,7 @@ class MemberTestJSON(base.BaseTestCase):
         member_id = self._create_member(self.pool_id,
                                         **member_opts)["id"]
         self.addCleanup(self._delete_member, self.pool_id, member_id)
-        member_opts = {"address": "127.0.0.69"}
+        member_opts = {"address": "128.0.0.69"}
         # The following code actually raises a 400 instead of a 422 as expected
         # Will need to consult with blogan as to what to fix
         self.assertRaises(ex.BadRequest, self._update_member,
@@ -446,7 +446,7 @@ class MemberTestJSON(base.BaseTestCase):
     @classmethod
     def build_member_opts(cls, **kw):
         """Build out default member dictionary """
-        opts = {"address": kw.get("address", "127.0.0.1"),
+        opts = {"address": kw.get("address", "128.0.0.1"),
                 "tenant_id": kw.get("tenant_id", cls.tenant_id),
                 "protocol_port": kw.get("protocol_port", 80),
                 "subnet_id": kw.get("subnet_id", cls.subnet_id)}


### PR DESCRIPTION
@szakeri 

Issues: Fixes #20

Problem:
The scenario tests for the mitaka branch fail due to request calls to VIP not properly configuring (or bypassing) ssl verification. We need to fix up the requests to have a context that allows the request to be verified.

Analysis:
Modified the requirements.txt file for mitaka to point to a tempest release that is known to work (12.1.0). Updated the request call to the VIP to have an ssl context.

Tests:
Ran tests manually in boulder lab.