### PR TITLE
Scenario tests in liberty failing due to AttributeError

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/scenario/base.py
+++ b/neutron_lbaas/tests/tempest/v2/scenario/base.py
@@ -72,6 +72,7 @@ class BaseTestCase(manager.NetworkScenarioTest):
 
     def setUp(self):
         super(BaseTestCase, self).setUp()
+        self.tenant_id = self.manager.identity_client.tenant_id
         self.servers_keypairs = {}
         self.servers = {}
         self.members = []


### PR DESCRIPTION
@dflanigan 

Fixes: Issue #23

Problem:
Six scenario tests are failing with AttributeError, object has no attribute
'tenant_id'.

Analysis:
Added call to set tenant_id at the beginning of the base.py's setUp function.

Tests:
Ran these scenario tests against an undercloud stack and five tests pass, but
the sixth fails due to another error.