### PR TITLE
Test session persistence scenario test in fails in mitaka

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/scenario/base.py
+++ b/neutron_lbaas/tests/tempest/v2/scenario/base.py
@@ -618,6 +618,11 @@ class BaseTestCase(manager.NetworkScenarioTest):
         if persistence_type:
             update_data = {"session_persistence": {
                 "type": persistence_type}}
+        else:
+            # If persistence_type is None, as it is by default, we should
+            # update the pool update_data dict to have session_persistence
+            # as None.
+            update_data = {'session_persistence': None}
         if cookie_name:
             update_data['session_persistence'].update(
                 {"cookie_name": cookie_name})


### PR DESCRIPTION
@szakeri @jlongstaf 

Issues:
Fixes #32

Problem:
Once session persistence has been set on a pool, it is impossible,
through the CLI, to set it back to None. It is possible to set it to
None via the api, but the test has a bug where it is not set properly.
We can fixit by calling the rest endpoint with the session_persistence
key set in the pool dict and the value equal to None.

Analysis:
Modified the base.py module for the scenario tests to set
session_persistence to None in the pool update_data dict when the
session persistence is updated for a given pool. This allows the
session_persistence to be set back to None.

Tests:
Ran test_session_persistence scenario tests against mitaka stack.

```
pytest-autolog: trace is disabled
rootdir: /home, inifile:
plugins: autolog-0.1.0a3, symbols-0.1.0a3, meta-0.1.1, f5-sdk-2.3.3
collected 1 items
pytest-meta: discarded 0 items

test_session_persistence.py::TestSessionPersistence::test_session_persistence <- jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED

```