### PR TITLE
stable/newton api test timeout is set at 10 minutes

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/base.py
+++ b/neutron_lbaas/tests/tempest/v2/api/base.py
@@ -174,7 +174,7 @@ class BaseTestCase(base.BaseNetworkTest):
                                        operating_status='ONLINE',
                                        delete=False):
         interval_time = 1
-        timeout = 600
+        timeout = 60
         end_time = time.time() + timeout
         lb = {}
         while time.time() < end_time:


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #34

Problem:
In the tempest api tests, the timeout for waiting for a loadbalancer to
become active and online is 600 seconds. We have brought this time down
to 60 seconds for other openstack releases. We should do the same for
newton.

Analysis:
Changed the timeout to 60 seconds.

Tests:
Ran api tests on a local stable/newton stack.