### PR TITLE
Wait for loadbalancer port to be removed before subnet delete operation

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/base.py
+++ b/neutron_lbaas/tests/tempest/v2/api/base.py
@@ -120,6 +120,11 @@ class BaseTestCase(base.BaseNetworkTest):
             test_utils.call_and_ignore_notfound_exc(
                 cls._delete_load_balancer, lb_id)
 
+        # Wait 5 seconds before tearing down network, this will give some time
+        # for the loadbalancer port to be removed.
+        LOG.info("Wait for VIP port teardown")
+        time.sleep(5)
+
         super(BaseTestCase, cls).resource_cleanup()
 
     @classmethod


### PR DESCRIPTION
Add a sleep to account for the time it takes to teardown the loadbalancer and the VIP port.