### PR TITLE
Adding waits for loadbalancer resources to be deleted in cleanup

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/base.py
+++ b/neutron_lbaas/tests/tempest/v2/api/base.py
@@ -229,9 +229,15 @@ class BaseTestCase(base.BaseNetworkTest):
     @classmethod
     def _delete_load_balancer(cls, load_balancer_id, wait=True):
         cls.load_balancers_client.delete_load_balancer(load_balancer_id)
+        lb = cls.load_balancers_client.get_load_balancer(load_balancer_id)
+        lb_vip_port_id = lb.get('vip_port_id')
+        LOG.debug("_delete_load_balancer")
         if wait:
             cls._wait_for_load_balancer_status(
                 load_balancer_id, delete=True)
+
+            cls._wait_for_vip_port_delete(
+                lb_vip_port_id)
 
     @classmethod
     def _update_load_balancer(cls, load_balancer_id, wait=True, **lb_kwargs):
@@ -257,6 +263,23 @@ class BaseTestCase(base.BaseNetworkTest):
                 ignore_operating_status=True)
 
     @classmethod
+    def _wait_for_vip_port_delete(cls, port_id):
+        interval_time = 1
+        timeout = 60
+        end_time = time.time() + timeout
+        port = dict()
+
+        while time.time() < end_time:
+            LOG.debug("_wait_for_vip_port_delete: %s" % port_id)
+            time.sleep(interval_time)
+            try:
+                port = cls.ports_client.show_port(port_id)
+                if not port:
+                    break
+            except exceptions.NotFound:
+                break
+
+    @classmethod
     def _wait_for_load_balancer_status(cls, load_balancer_id,
                                        provisioning_status='ACTIVE',
                                        operating_status='ONLINE',
@@ -270,6 +293,7 @@ class BaseTestCase(base.BaseNetworkTest):
             try:
                 lb = cls.load_balancers_client.get_load_balancer(
                     load_balancer_id)
+                LOG.debug("_wait_for_load_balancer_status: %s", lb)
                 if not lb:
                         # loadbalancer not found
                     if delete:
@@ -321,9 +345,25 @@ class BaseTestCase(base.BaseNetworkTest):
 
     @classmethod
     def _delete_listener(cls, listener_id, wait=True):
+        interval_time = 1
+        timeout = 10
+        end_time = time.time() + timeout
+        listener = {}
+        lb_id = cls.load_balancer.get('id')
         cls.listeners_client.delete_listener(listener_id)
+
         if wait:
-            cls._wait_for_load_balancer_status(cls.load_balancer.get('id'))
+            while time.time() < end_time:
+                try:
+                    listener = cls.listeners_client.get_listener(
+                        listener_id)
+                    if not listener:
+                        break
+                except exceptions.NotFound:
+                    break
+                time.sleep(interval_time)
+
+            cls._wait_for_load_balancer_status(lb_id)
 
     @classmethod
     def _update_listener(cls, listener_id, wait=True, **listener_kwargs):
@@ -343,8 +383,23 @@ class BaseTestCase(base.BaseNetworkTest):
 
     @classmethod
     def _delete_pool(cls, pool_id, wait=True):
+        interval_time = 1
+        timeout = 10
+        end_time = time.time() + timeout
+        pool = {}
+
         cls.pools_client.delete_pool(pool_id)
         if wait:
+            while time.time() < end_time:
+                try:
+                    pool = cls.pools_client.get_pool(
+                        pool_id)
+                    if not pool:
+                        break
+                except exceptions.NotFound:
+                    break
+                time.sleep(interval_time)
+
             cls._wait_for_load_balancer_status(cls.load_balancer.get('id'))
 
     @classmethod

--- a/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import time
+
 from tempest.lib.common.utils import data_utils
 from tempest.lib import exceptions as ex
 from tempest import test
@@ -52,6 +54,10 @@ class TestHealthMonitors(base.BaseTestCase):
         cls.create_basic_hm_kwargs = {'type': 'HTTP', 'delay': 3,
                                       'max_retries': 10, 'timeout': 5,
                                       'pool_id': cls.pool.get('id')}
+
+    def tearDown(self):
+        time.sleep(2)
+        super(TestHealthMonitors, self).tearDown()
 
     @test.attr(type='smoke')
     def test_list_health_monitors_empty(self):

--- a/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import time
+
 from tempest import config
 from tempest.lib.common.utils import data_utils
 from tempest.lib import exceptions as ex
@@ -63,6 +65,10 @@ class MemberTestJSON(base.BaseTestCase):
     @classmethod
     def resource_cleanup(cls):
         super(MemberTestJSON, cls).resource_cleanup()
+
+    def tearDown(self):
+        time.sleep(2)
+        super(MemberTestJSON, self).tearDown()
 
     @test.attr(type='smoke')
     def test_list_empty_members(self):


### PR DESCRIPTION


Add some logic to teardown of load balancers, listeners, and pools to:

Wait for VIP port to be removed before tearing down VIP subnet
Wait for listener to be deleted before exiting delete_listener
Wait for pool to be deleted before exiting delete_pool
Add some short sleep timeouts to Member and Healthmonitor test suites.

Tests:
Ran all Neutron LBaaS API tests in cluster environment.

(cherry picked from commit 6726cf2a98ae5b2aa6d570a30a36ba5e66252f28)