### PR TITLE
skipping the loadbalancer admin tests that can't run against our env

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py
@@ -18,7 +18,7 @@ from tempest.lib.common.utils import data_utils
 from tempest.lib.common.utils import test_utils
 from tempest.lib import exceptions as ex
 from tempest import test
-
+import pytest
 from neutron_lbaas.tests.tempest.v2.api import base
 
 
@@ -68,6 +68,7 @@ class LoadBalancersTestAdmin(base.BaseAdminTestCase):
         cls._wait_for_load_balancer_status(
             load_balancer_id=cls.tenant_load_balancer['id'], delete=True)
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='smoke')
     def test_create_load_balancer_missing_tenant_id_field_for_admin(self):
         """
@@ -80,6 +81,7 @@ class LoadBalancersTestAdmin(base.BaseAdminTestCase):
         self.assertEqual(self.load_balancer.get('tenant_id'),
                          admin_lb.get('tenant_id'))
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='smoke')
     def test_create_load_balancer_missing_tenant_id_for_tenant(self):
         """
@@ -90,6 +92,7 @@ class LoadBalancersTestAdmin(base.BaseAdminTestCase):
         self.assertNotEqual(self.load_balancer.get('tenant_id'),
                             self.subnet['tenant_id'])
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='negative')
     def test_create_load_balancer_empty_tenant_id_field(self):
         """Test create load balancer with empty tenant_id field should fail"""
@@ -99,12 +102,14 @@ class LoadBalancersTestAdmin(base.BaseAdminTestCase):
                           wait=False,
                           tenant_id="")
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='smoke')
     def test_create_load_balancer_for_another_tenant(self):
         """Test create load balancer for other tenant"""
         self.assertEqual(self.tenant,
                          self.tenant_load_balancer.get('tenant_id'))
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='smoke')
     def test_update_load_balancer_description(self):
         """Test update admin load balancer description"""
@@ -115,6 +120,7 @@ class LoadBalancersTestAdmin(base.BaseAdminTestCase):
             self.load_balancer['id'])
         self.assertEqual(new_description, load_balancer.get('description'))
 
+    @pytest.mark.skip(reason="The network setting for the test doesn't work with our env")
     @test.attr(type='smoke')
     def test_delete_load_balancer_for_tenant(self):
         """Test delete another tenant's load balancer as admin"""


### PR DESCRIPTION
@jlongstaf

What issues does this address?
Fixes : issue in systest common repo

What's this change do?
This change will mark the tests that can not run against our environment and skip them.

Where should the reviewer start?
test_load_balancer_admin.py